### PR TITLE
Cloud Usage UI

### DIFF
--- a/ui/assets/dx-components-theme.css
+++ b/ui/assets/dx-components-theme.css
@@ -3,6 +3,7 @@
  */
 @import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 @import url("https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css");
+@import url("https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css");
 
 body {
   color: var(--secondary-color-4);

--- a/ui/assets/dx-components-theme.css
+++ b/ui/assets/dx-components-theme.css
@@ -11,6 +11,27 @@ body {
   font-optical-sizing: auto;
   font-style: normal;
   font-weight: 400;
+  font-size: 15px;
+}
+
+h2 {
+  font-size: 32px;
+}
+
+h3 {
+  font-size: 24px;
+}
+
+h4 {
+  font-size: 20px;
+}
+
+h5 {
+  font-size: 16px;
+}
+
+h6 {
+  font-size: 15px;
 }
 
 html[data-theme="dark"] {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -7,9 +7,9 @@ mod components;
 mod pages;
 
 use components::button::{Button, ButtonVariant};
-use pages::{PricesPage, ProfilePage};
+use pages::{PricesPage, ProfilePage, UsagePage};
 
-const API_URL: &str = "http://localhost:8000/api";
+const API_URL: &str = "https://cc.lrz.de:1338/api";
 const THEME_CSS: Asset = asset!("../assets/dx-components-theme.css");
 
 fn main() {
@@ -19,6 +19,7 @@ fn main() {
 #[derive(Debug, EnumIter, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum Page {
     Prices,
+    Usage,
     Profile,
 }
 
@@ -85,6 +86,13 @@ fn app() -> Element {
                 signal,
                 Page::Prices,
                 PricesPage { api_url, token }
+            )
+        }
+        Page::Usage => {
+            rsx_with_page_bar!(
+                signal,
+                Page::Usage,
+                UsagePage { api_url, token }
             )
         }
         Page::Profile => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -43,6 +43,7 @@ macro_rules! rsx_with_page_bar {
             }
             br {}
             div {
+                class: "container-fluid",
                 $content
             }
         }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -9,6 +9,7 @@ mod pages;
 use components::button::{Button, ButtonVariant};
 use pages::{PricesPage, ProfilePage, UsagePage};
 
+// TODO: we should pass this in as arguments or so
 const API_URL: &str = "https://cc.lrz.de:1338/api";
 const THEME_CSS: Asset = asset!("../assets/dx-components-theme.css");
 

--- a/ui/src/pages/mod.rs
+++ b/ui/src/pages/mod.rs
@@ -1,5 +1,7 @@
 mod prices;
 mod profile;
+mod usage;
 
 pub use prices::PricesPage;
 pub use profile::ProfilePage;
+pub use usage::UsagePage;

--- a/ui/src/pages/usage.rs
+++ b/ui/src/pages/usage.rs
@@ -1,3 +1,6 @@
+use std::cmp::max;
+
+use avina_wire::resources::{CloudUsageAggregate, CloudUsageFlavorSlot};
 use dioxus::prelude::*;
 
 #[component]
@@ -52,6 +55,21 @@ pub fn UsagePage(api_url: String, token: String) -> Element {
                 unit: "",
             }
         }
+
+        br {}
+        br {}
+
+        FlavorSlotRow { title: "LRZ Flavor Slots", aggregates: usage.lrz_flavor_slots }
+
+        br {}
+        br {}
+
+        FlavorSlotRow { title: "ACH Flavor Slots", aggregates: usage.ach_flavor_slots }
+
+        br {}
+        br {}
+
+        FlavorSlotRow { title: "Other Flavor Slots", aggregates: usage.other_flavor_slots }
     }
 }
 
@@ -97,6 +115,75 @@ fn PieChart(name: String, used: u64, total: u64, unit: String) -> Element {
                 class: "text-center",
                 "Used {used}{unit} of {total}{unit}"
             }
+        }
+    }
+}
+
+#[component]
+fn FlavorSlotRow(
+    title: String,
+    aggregates: Vec<CloudUsageAggregate>,
+) -> Element {
+    rsx! {
+        div {
+            class: "row",
+            h3 { "{title}" }
+            br {}
+            for aggregate in aggregates {
+                div {
+                    class: "col-lg-4",
+                    class: "col-md-4",
+                    class: "col-sm-6",
+                    class: "col-xs-12",
+                    h4 { "{aggregate.title}" },
+                    FlavorSlotTable { slots: aggregate.flavors }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn FlavorSlotTable(slots: Vec<CloudUsageFlavorSlot>) -> Element {
+    rsx! {
+        div {
+            class: "table_wrapper",
+            table {
+                class: "table",
+                style: "--bs-table-bg: #eeeeee;",
+                thead {
+                    tr {
+                        th { "Flavor" },
+                        th { "Slots (available)" },
+                        th { "Slots (total)"},
+                    }
+                }
+                tbody {
+                    for slot in slots {
+                        FlavorSlotTableRow { slot }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn FlavorSlotTableRow(slot: CloudUsageFlavorSlot) -> Element {
+    if slot.free < 0 {
+        tracing::warn!(
+            "Negative flavor slot free value for flavor {}.",
+            slot.name
+        );
+    }
+    let free = max(0, slot.free);
+    let color = if free > 0 { "#ccffcc" } else { "#ffcccc" };
+    rsx! {
+        tr {
+            style: "--bs-table-bg: {color}",
+            td { "{slot.name}" },
+            td { "{free}" },
+            td { "{slot.total}" },
         }
     }
 }

--- a/ui/src/pages/usage.rs
+++ b/ui/src/pages/usage.rs
@@ -1,0 +1,16 @@
+use dioxus::prelude::*;
+
+#[component]
+pub fn UsagePage(api_url: String, token: String) -> Element {
+    let usage = api_call!(api_url, token, api, api.usage.get().await);
+
+    rsx! {
+        h2 { "Cloud Usage" }
+        hr {}
+
+        p {
+            class: "text-end",
+            "Last updated: {usage.datetime}"
+        }
+    }
+}

--- a/ui/src/pages/usage.rs
+++ b/ui/src/pages/usage.rs
@@ -3,7 +3,6 @@ use dioxus::prelude::*;
 #[component]
 pub fn UsagePage(api_url: String, token: String) -> Element {
     let usage = api_call!(api_url, token, api, api.usage.get().await);
-
     rsx! {
         h2 { "Cloud Usage" }
         hr {}
@@ -11,6 +10,93 @@ pub fn UsagePage(api_url: String, token: String) -> Element {
         p {
             class: "text-end",
             "Last updated: {usage.datetime}"
+        }
+
+        div {
+            class: "row",
+            h3 { "Public Resources Overview" }
+            PieChart {
+                name: "vCPU",
+                used: usage.overview.vcpus.used,
+                total: usage.overview.vcpus.total,
+                unit: "",
+            }
+            PieChart {
+                name: "RAM",
+                used: usage.overview.ram.used / 1_000_000,
+                total: usage.overview.ram.total / 1_000_000,
+                unit: "TB",
+            }
+            PieChart {
+                name: "GPU",
+                used: usage.overview.gpus.used,
+                total: usage.overview.gpus.total,
+                unit: "",
+            }
+            PieChart {
+                name: "Storage",
+                used: (usage.overview.storage.used / 1024.) as u64,
+                total: (usage.overview.storage.total / 1024.) as u64,
+                unit: "TiB",
+            }
+            PieChart {
+                name: "MWN Floating IP",
+                used: usage.overview.mwn_ips.used,
+                total: usage.overview.mwn_ips.total,
+                unit: "",
+            }
+            PieChart {
+                name: "Internet Floating IP",
+                used: usage.overview.www_ips.used,
+                total: usage.overview.www_ips.total,
+                unit: "",
+            }
+        }
+    }
+}
+
+#[component]
+fn PieChart(name: String, used: u64, total: u64, unit: String) -> Element {
+    let ratio = used as f64 / total as f64;
+    let percentage = (ratio * 100.).round() as u32;
+    let color = match ratio {
+        _ if ratio < 0.75 => "rgba(109, 173, 223, 1.0)",
+        _ if ratio < 0.9 => "rgba(240, 173, 78, 1.0)",
+        _ => "rgba(240, 78, 78, 1.0)",
+    }
+    .to_string();
+    rsx! {
+        div {
+            class: "col-lg-2",
+            class: "col-md-4",
+            class: "col-sm-4",
+            class: "col-xs-6",
+            div {
+                table {
+                    width: "100px",
+                    class: "charts-css",
+                    class: "pie",
+                    tbody {
+                        tr {
+                            td {
+                                style: "--start: 0.0; --end: {ratio}; --color: {color};",
+                            }
+                            td {
+                                style: "--start: {ratio}; --end: 1.0; --color: rgba(0, 0, 0, 0.0);",
+                            }
+                        }
+                    }
+                }
+            }
+            br {}
+            h5 {
+                class: "text-center",
+                "{name} Usage: {percentage}%"
+            }
+            h6 {
+                class: "text-center",
+                "Used {used}{unit} of {total}{unit}"
+            }
         }
     }
 }

--- a/wire/src/resources/usage.rs
+++ b/wire/src/resources/usage.rs
@@ -25,7 +25,7 @@ pub struct CloudUsageOverview {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct CloudUsageFlavorSlot {
     pub name: String,
-    pub free: u32,
+    pub free: i32,
     pub total: u32,
 }
 


### PR DESCRIPTION
- **fix(wire/usage): make CloudUsageFlavorSlot.free an i32**
- **feat(ui): add bare UsagePage only displaying timestamp**
- **build(ui/theme): import charts css**
